### PR TITLE
Escaped asterisk in 2450 display.settext

### DIFF
--- a/server/src/instrument/2450/display.ts
+++ b/server/src/instrument/2450/display.ts
@@ -110,7 +110,7 @@ This setting persists through reset() and power cycles.'
             kind: MarkupKind.Markdown,
             value: '```lua\nfunction settext(position, userDisplayText)\n```\n\
 \n\
-display.settext(display.TEXT*, userDisplayText)\n\
+display.settext(display.TEXT\\*, userDisplayText)\n\
 \n\
 Set USER_SWIPE screen messages.\n\
 \n\


### PR DESCRIPTION
### Pull Request Checklist
Please review the [Contribution Guidelines](../CONTRIBUTING.md) before submitting.

- [x] Pulling from a topic/feature/bugfix branch (right side).
- [x] Pulling against the `dev` branch (left side).
- [x] Code passes linting.
- [x] Code passes unit tests.
- [x] Code coverage is the same or better.
- [x] You have previously submitted a Contributor License Agreement or have contacted a maintainer to request one.

### Description
Escaped an asterisk in the documentation for 2450 display.settext as per Issue #1. 



<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
