### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![build](https://travis-ci.com/tektronix/vscode-tsplang.svg?branch=master)](https://travis-ci.com/tektronix/vscode-tsplang)
 [![codecov](https://codecov.io/gh/tektronix/vscode-tsplang/branch/master/graph/badge.svg)](https://codecov.io/gh/tektronix/vscode-tsplang)
+[![Code Quality: Javascript](https://img.shields.io/lgtm/grade/javascript/g/tektronix/vscode-tsplang.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tektronix/vscode-tsplang/context:javascript)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/tektronix/vscode-tsplang.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tektronix/vscode-tsplang/alerts)
 
 The TSP language extension for [Visual Studio Code](https://code.visualstudio.com/) provides command completions for [supported](#supported-instruments) TSP-enabled Keithley Instruments.
 


### PR DESCRIPTION
Hi there!

We've been pleased to meet one of your contributors @zkoppert at GitHubUniverse and chat about LGTM.

I thought you might be interested in adding these LGTM [code quality badges](https://lgtm.com/projects/g/tektronix/vscode-tsplang/ci/#badges) to your project, to show how you care about code quality and encourage contributors to do the same.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/tektronix/vscode-tsplang).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
