### PR TITLE
Instrument Provider Unit Tests

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -13,6 +13,7 @@
         "server/src/antlr4-tsplang",
         "server/src/instrument/2461",
         "server/src/instrument/6500",
+        "server/src/instrument/provider/test",
         "server/src/test"
     ],
     "reporter": [

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -192,11 +192,6 @@ function generateRoots(completions: Array<CompletionItem>): Array<CompletionItem
     uniqueNamespaces.forEach((uniqueItem: CompletionItem) => {
         const fullyQualifiedCompletion = CompletionItem.resolveNamespace(uniqueItem)
 
-        // Throw an error if this completion has no domain.
-        if (uniqueItem.data === undefined || uniqueItem.data.domains.length === 0) {
-            throw new Error(`Unable to generate root completion for '${fullyQualifiedCompletion}'.`)
-        }
-
         // Create root completion items and add them to the results.
         results.push(...CompletionItem.createRootItems(fullyQualifiedCompletion, true))
     })

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -266,8 +266,12 @@ function addSignatureExclusives(
 
                 const filteredEnums = filterEnums(paramCompletionSpec, enumModule)
 
-                if (filteredEnums.length === 0) {
-                    return
+                // Throw an error so ApiSpec bugs can be differentiated language comprehension bugs.
+                if (filteredEnums.length !== paramCompletionSpec.length) {
+                    throw new Error(
+                        `Unable to satisfy exclusives for parameter ${key} of `
+                            + `"${SignatureInformation.resolveNamespace(signature)}"`
+                    )
                 }
 
                 // Add all root namespace completions to the array of enumeration completions.
@@ -276,14 +280,6 @@ function addSignatureExclusives(
                 parameterMap.set(key, filteredEnums)
             })
         })
-
-        // Something went wrong if we are here but have nothing to show for it.
-        if (parameterMap.size === 0) {
-            throw new Error([
-                'No parameter completions available for',
-                `'${SignatureInformation.resolveNamespace(signature)}'.`
-            ].join(' '))
-        }
 
         signature.data.parameterTypes = parameterMap
 

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -216,12 +216,12 @@ function addAssignmentExclusives(
 
         const filteredEnums = filterEnums(exclusives, enumModule)
 
-        // Something went wrong if we are here but have nothing to show for it.
-        if (filteredEnums.length === 0) {
-            throw new Error([
-                'No assignment completions available for',
-                `'${CompletionItem.resolveNamespace(completion)}'.`
-            ].join(' '))
+        // Throw an error so ApiSpec bugs can be differentiated language comprehension bugs.
+        if (filteredEnums.length !== exclusives.length) {
+            throw new Error(
+                'Unable to satisfy assignment exclusives for '
+                    + `"${CompletionItem.resolveNamespace(completion)}"`,
+            )
         }
 
         // Add all root namespace completions to the array of enumeration completions.

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -58,71 +58,40 @@ function filter(
     }
 
     const filteredModule: CommandSetInterface = {
-        completions: new Array()
+        completionDocs: new Map(),
+        completions: new Array(),
+        signatures: new Array()
     }
 
-    // The following labels are not to be treated as root namespaces.
-    if (namespace.label.localeCompare('keywords') !== 0
-        && namespace.label.localeCompare('functions') !== 0) {
-        // If this module contains completion docs for the namespace label.
-        if (providerMap.completionDocs.has(namespace.label)) {
-            const completionDocs = providerMap.completionDocs.get(namespace.label)
+    // If this module contains completion docs for the namespace label.
+    if (providerMap.completionDocs.has(namespace.label)) {
+        const completionDocs = providerMap.completionDocs.get(namespace.label)
 
-            if (completionDocs === undefined) {
-                throw new Error(`Filter Error: no completionDocs found with the label "${namespace.label}".`)
-            }
+        // Add root namespace documentation to the results.
+        filteredModule.completionDocs.set(namespace.label, completionDocs)
+    }
 
-            if (filteredModule.completionDocs === undefined) {
-                filteredModule.completionDocs = new Map()
-            }
+    // If this module contains a completion with the namespace label.
+    if (providerMap.completions.has(namespace.label)) {
+        const completions = providerMap.completions.get(namespace.label)
 
-            // Add root namespace documentation to the results.
-            filteredModule.completionDocs.set(namespace.label, completionDocs)
-        }
+        // Add root namespaces to the results.
+        filteredModule.completions.push(...completions)
+    }
 
-        // If this module contains a completion with the namespace label.
-        if (providerMap.completions.has(namespace.label)) {
-            const completions = providerMap.completions.get(namespace.label)
+    // If this module contains a signature with the namespace label.
+    if (providerMap.signatures.has(namespace.label)) {
+        const signatures = providerMap.signatures.get(namespace.label)
 
-            if (completions === undefined) {
-                throw new Error(`Filter Error: no completions found with the label "${namespace.label}".`)
-            }
-
-            // Add root namespaces to the results.
-            filteredModule.completions.push(...completions)
-        }
-
-        // If this module contains a signature with the namespace label.
-        if (providerMap.signatures.has(namespace.label)) {
-            const signatures = providerMap.signatures.get(namespace.label)
-
-            if (signatures === undefined) {
-                throw new Error(`Filter Error: no signatures found with the label "${namespace.label}".`)
-            }
-
-            if (filteredModule.signatures === undefined) {
-                filteredModule.signatures = new Array()
-            }
-
-            // Add root namespace signatures to the results.
-            filteredModule.signatures.push(...signatures)
-        }
+        // Add root namespace signatures to the results.
+        filteredModule.signatures.push(...signatures)
     }
 
     if (namespace.children !== undefined) {
         namespace.children.forEach((child: ChildApiSpec) => {
             // Get any completionDocs for this child.
             if (providerMap.completionDocs.has(child.label)) {
-                // Instantiate the property if we have yet to do so.
-                if (filteredModule.completionDocs === undefined) {
-                    filteredModule.completionDocs = new Map()
-                }
-
                 const completionDoc = providerMap.completionDocs.get(child.label)
-
-                if (completionDoc === undefined) {
-                    throw new Error(`Filter Error: no completion documentation with the label "${child.label}".`)
-                }
 
                 filteredModule.completionDocs.set(child.label, completionDoc)
             }
@@ -130,10 +99,6 @@ function filter(
             // Get any completions for this child.
             if (providerMap.completions.has(child.label)) {
                 let completions = providerMap.completions.get(child.label)
-
-                if (completions === undefined) {
-                    throw new Error(`Filter Error: no completions found with the label "${child.label}".`)
-                }
 
                 if (child.assignmentExclusives !== undefined) {
                     completions = addAssignmentExclusives(
@@ -148,16 +113,7 @@ function filter(
 
             // Get any signatures for this child.
             if (providerMap.signatures.has(child.label)) {
-                // Instantiate the property if we have yet to do so.
-                if (filteredModule.signatures === undefined) {
-                    filteredModule.signatures = new Array()
-                }
-
                 let signatures = providerMap.signatures.get(child.label)
-
-                if (signatures === undefined) {
-                    throw new Error(`Filter Error: no signatures found with the label "${child.label}".`)
-                }
 
                 // Add any parameter exclusive completions.
                 if (child.signatureExclusives !== undefined) {
@@ -173,6 +129,14 @@ function filter(
         })
     }
 
+    if (filteredModule.completionDocs.size === 0) {
+        filteredModule.completionDocs = undefined
+    }
+
+    if (filteredModule.signatures.length === 0) {
+        filteredModule.signatures = undefined
+    }
+
     return filteredModule
 }
 
@@ -180,7 +144,7 @@ function filter(
  * Returns all Enumeration elements of the CommandSetInterface that can be found in the ApiSpec.
  */
 function filterEnums(
-    namespace: ApiSpec,
+    enums: Array<ExclusiveCompletionApiSpec>,
     enumModule: CommandSetInterface
 ): Array<CompletionItem> {
     // Create an object of Maps whose keys will match against ApiSpec labels.
@@ -188,20 +152,14 @@ function filterEnums(
 
     const filteredEnumerations = new Array<CompletionItem>()
 
-    if (namespace.enums !== undefined) {
-        namespace.enums.forEach((enumeration: BaseApiSpec) => {
-            // Get any completions for this enumeration.
-            if (completionMap.has(enumeration.label)) {
-                const enumerations = completionMap.get(enumeration.label)
+    enums.forEach((enumeration: BaseApiSpec) => {
+        // Get any completions for this enumeration.
+        if (completionMap.has(enumeration.label)) {
+            const enumerations = completionMap.get(enumeration.label)
 
-                if (enumerations === undefined) {
-                    throw new Error(`Filter Error: no enumerations found with the label "${enumeration.label}".`)
-                }
-
-                filteredEnumerations.push(...enumerations)
-            }
-        })
-    }
+            filteredEnumerations.push(...enumerations)
+        }
+    })
 
     return filteredEnumerations
 }
@@ -259,10 +217,9 @@ function addAssignmentExclusives(
         }
 
         // Collect an array of enumerations as listed in the assignment completion spec.
-        const enumApiSpec: ApiSpec = { enums: exclusives, label: '' }
         const enumModule: CommandSetInterface = { completions: enumerations }
 
-        const filteredEnums = filterEnums(enumApiSpec, enumModule)
+        const filteredEnums = filterEnums(exclusives, enumModule)
 
         // Something went wrong if we are here but have nothing to show for it.
         if (filteredEnums.length === 0) {
@@ -310,10 +267,9 @@ function addSignatureExclusives(
             // Collect an array of enumerations as listed in each parameter completion spec of the
             // current signature spec.
             spec.parameters.forEach((paramCompletionSpec: Array<ExclusiveCompletionApiSpec>, key: number) => {
-                const enumApiSpec: ApiSpec = { enums: paramCompletionSpec, label: '' }
                 const enumModule: CommandSetInterface = { completions: enumerations }
 
-                const filteredEnums = filterEnums(enumApiSpec, enumModule)
+                const filteredEnums = filterEnums(paramCompletionSpec, enumModule)
 
                 if (filteredEnums.length === 0) {
                     return
@@ -391,7 +347,7 @@ export function generateCommandSet(apiSpecs: Array<ApiSpec>, spec: InstrumentSpe
 
         const enumModule: CommandSetInterface = require(labelToModuleName(api.label, true))
 
-        enumerations.push(...filterEnums(api, enumModule))
+        enumerations.push(...filterEnums(api.enums, enumModule))
     })
 
     const result: CommandSet = new CommandSet(spec)

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -391,7 +391,7 @@ export function generateCommandSet(apiSpecs: Array<ApiSpec>, spec: InstrumentSpe
 
         const enumModule: CommandSetInterface = require(labelToModuleName(api.label, true))
 
-        enumerations.push(...enumModule.completions)
+        enumerations.push(...filterEnums(api, enumModule))
     })
 
     const result: CommandSet = new CommandSet(spec)

--- a/server/src/instrument/provider/index.ts
+++ b/server/src/instrument/provider/index.ts
@@ -211,11 +211,6 @@ function addAssignmentExclusives(
 ): Array<CompletionItem> {
     // Modify each completion item.
     const modifiedCompletions = completions.map((completion: CompletionItem) => {
-        // Return an unmodified completion item if it is a root namespace.
-        if (completion.data === undefined) {
-            return completion
-        }
-
         // Collect an array of enumerations as listed in the assignment completion spec.
         const enumModule: CommandSetInterface = { completions: enumerations }
 

--- a/server/src/instrument/provider/test/root-completion-docs.ts
+++ b/server/src/instrument/provider/test/root-completion-docs.ts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2018 Tektronix Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+'use strict'
+
+import { CompletionItemKind } from 'vscode-languageserver'
+
+import { InstrumentSpec } from '../..'
+import { CompletionItem, MarkupContent, MarkupContentCallback } from '../../../decorators'
+
+export const completionDocs: Map<string, MarkupContentCallback> = new Map([
+    [
+        'test/root.completion.docs',
+        (spec: InstrumentSpec): MarkupContent => MarkupContent`
+This tests the ability of the provider to generate a CommandSet containing the completion documentation associated
+with a Root Namespace completion.`
+    ]
+])
+
+export const completions: Array<CompletionItem> = [
+    {
+        data: { domains: ['completion', 'test/root'] },
+        kind: CompletionItemKind.Module,
+        label: 'docs'
+    }
+]

--- a/server/src/test/instrument/2450/index.test.ts
+++ b/server/src/test/instrument/2450/index.test.ts
@@ -111,11 +111,12 @@ describe('Instrument Specification', () => {
                 specs = instrumentModule.getApiSpec()
             })
 
-            it('contains all known namespaces', () => {
-                knownNamespaces.forEach((namespace: string) => {
-                    const result = specs.some((spec: ApiSpec) => spec.label.localeCompare(namespace) === 0)
-
-                    expect(result, `failed to contain the "${namespace}" namespace`).to.be.true
+            knownNamespaces.forEach((label: string) => {
+                it(`contains the ${label} namespace`, () => {
+                    expect(
+                        specs.some((spec: ApiSpec) => spec.label.localeCompare(label) === 0),
+                        `failed to contain the "${label}" namespace`
+                    ).to.be.true
                 })
             })
 

--- a/server/src/test/instrument/2460/index.test.ts
+++ b/server/src/test/instrument/2460/index.test.ts
@@ -111,11 +111,12 @@ describe('Instrument Specification', () => {
                 specs = instrumentModule.getApiSpec()
             })
 
-            it('contains all known namespaces', () => {
-                knownNamespaces.forEach((namespace: string) => {
-                    const result = specs.some((spec: ApiSpec) => spec.label.localeCompare(namespace) === 0)
-
-                    expect(result, `failed to contain the "${namespace}" namespace`).to.be.true
+            knownNamespaces.forEach((label: string) => {
+                it(`contains the ${label} namespace`, () => {
+                    expect(
+                        specs.some((spec: ApiSpec) => spec.label.localeCompare(label) === 0),
+                        `failed to contain the "${label}" namespace`
+                    ).to.be.true
                 })
             })
 

--- a/server/src/test/instrument/lua/index.test.ts
+++ b/server/src/test/instrument/lua/index.test.ts
@@ -55,11 +55,12 @@ describe('Instrument Specification', () => {
                 specs = instrumentModule.getApiSpec()
             })
 
-            it('contains all known namespaces', () => {
-                knownNamespaces.forEach((namespace: string) => {
-                    const result = specs.some((spec: ApiSpec) => spec.label.localeCompare(namespace) === 0)
-
-                    expect(result, `failed to contain the "${namespace}" namespace`).to.be.true
+            knownNamespaces.forEach((label: string) => {
+                it(`contains the ${label} namespace`, () => {
+                    expect(
+                        specs.some((spec: ApiSpec) => spec.label.localeCompare(label) === 0),
+                        `failed to contain the "${label}" namespace`
+                    ).to.be.true
                 })
             })
 

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -13,30 +13,204 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-// tslint:disable:no-implicit-dependencies no-unused-expression
+// tslint:disable:no-implicit-dependencies no-unused-expression no-magic-numbers
 import { expect } from 'chai'
 // tslint:disable-next-line:no-import-side-effect
 import 'mocha'
 // tslint:enable:no-implicit-dependencies
 
+import { CompletionItem, ResolvedNamespace, SignatureInformation } from '../../../decorators'
+import { ApiSpec, CommandSet } from '../../../instrument'
 import { generateCommandSet } from '../../../instrument/provider'
+import { emptySpec } from '../emptySpec'
+
+import { expectSignatureFormat } from './helpers'
 
 describe('Instrument Provider', () => {
     describe('generateCommandSet()', () => {
-        it.skip('needs test coverage')
+        // Gets completions
+        const basicSpec: Array<ApiSpec> = [
+            {
+                children: [
+                    // Gets signatures
+                    // Formats parameters based on the given InstrumentSpec
+                    { label: 'beeper.beep' }
+                ],
+                label: 'beeper'
+            },
+            {
+                children: [
+                    // Gets completion documentation
+                    { label: 'smu.measure.range' }
+                ],
+                label: 'smu.measure'
+            }
+        ]
+        let commandSet: CommandSet
 
-        it.skip('returns a CommandSet containing items which match the given ApiSpec')
-        it.skip('returns a CommandSet whose signatures have been formatted according the given InstrumentSpec')
-        it.skip('returns a CommandSet without extra items')
+        before('Generate', () => {
+            commandSet = generateCommandSet(basicSpec, emptySpec)
+        })
 
-        it.skip('assignment completions')
-        it.skip('populates same-namespace enumeration specs')
-        it.skip('populates cross-namespace enumeration specs')
+        describe('return', () => {
+            describe('#completionDocs', () => {
+                const expectedLabels: Array<string> = ['smu.measure.range']
 
-        it.skip('parameter completions')
-        it.skip('populates the correct parameter')
-        it.skip('populates the correct signature qualifier')
-        it.skip('populates same-namespace enumeration specs')
-        it.skip('populates cross-namespace enumeration specs')
+                expectedLabels.forEach((label: string) => {
+                    it(`Contains a "${label}" key`, () => {
+                        expect([...commandSet.completionDocs.keys()]).to.contain('smu.measure.range')
+                    })
+                })
+
+                it('Contains no additional items', () => {
+                    expect(commandSet.completionDocs.size).to.equal(expectedLabels.length)
+                })
+            })
+
+            describe('#completions', () => {
+                const expectedLabels: Array<string> = [
+                    'beeper',
+                    'beeper.beep',
+                    'smu.measure',
+                    'smu.measure.range'
+                ]
+
+                expectedLabels.forEach((label: string) => {
+                    it(`Contains a "${label}" completion`, () => {
+                        expect(commandSet.completions.some(
+                            (completion: CompletionItem) => CompletionItem.namespaceMatch(label, completion)
+                        )).to.be.true
+                    })
+                })
+
+                it('Contains no additional items', () => {
+                    expect(commandSet.completions.length).to.equal(expectedLabels.length)
+                })
+            })
+
+            describe('#signatures', () => {
+                const expectedLabels: Array<string> = ['beeper.beep']
+                const formattableLabels: Array<string> = expectedLabels
+
+                expectedLabels.forEach((label: string) => {
+                    it(`Contains a "${label}" signature`, () => {
+                        expect(commandSet.signatures.some(
+                            (signature: SignatureInformation) => ResolvedNamespace.equal(
+                                label,
+                                SignatureInformation.resolveNamespace(signature)
+                            )
+                        )).to.be.true
+                    })
+                })
+
+                formattableLabels.forEach((label: string) => {
+                    it(`Signature "${label}" should be formatted`, () => {
+                        expectSignatureFormat(commandSet.signatures.find(
+                            (signature: SignatureInformation) => ResolvedNamespace.equal(
+                                label,
+                                SignatureInformation.resolveNamespace(signature)
+                            )
+                        ))
+                    })
+                })
+
+                it('Contains no additional items', () => {
+                    expect(commandSet.signatures.length).to.equal(expectedLabels.length)
+                })
+            })
+        })
+
+        // Same-namespace exclusives
+        const specB: Array<ApiSpec> = [
+            {
+                children: [
+                    {
+                        // Populates assignment exclusives
+                        assignmentExclusives: [
+                            { label: 'buffer.FILL_CONTINUOUS' },
+                            { label: 'buffer.FILL_ONCE' }
+                        ],
+                        label: 'buffer.write.reading',
+                        // Populates signature exclusives
+                        signatureExclusives: [
+                            // Respects signature qualifiers
+                            {
+                                parameters: new Map([
+                                    [
+                                        4,
+                                        [
+                                            { label: 'buffer.OFF' }
+                                        ]
+                                    ],
+                                ]),
+                                qualifier: 0
+                            },
+                            {
+                                parameters: new Map([
+                                    [
+                                        5,
+                                        [
+                                            { label: 'buffer.ON' }
+                                        ]
+                                    ],
+                                ]),
+                                qualifier: 1
+                            },
+                        ]
+                    }
+                ],
+                label: 'buffer.write'
+            },
+            {
+                enums: [
+                    { label: 'buffer.FILL_CONTINUOUS' },
+                    { label: 'buffer.FILL_ONCE' },
+                    { label: 'buffer.OFF' },
+                    { label: 'buffer.ON' }
+                ],
+                label: 'buffer'
+            }
+        ]
+        // Cross-namespace exclusives
+        const specC: Array<ApiSpec> = [
+            {
+                children: [
+                    {
+                        assignmentExclusives: [
+                            { label: 'smu.ON' }
+                        ],
+                        label: 'eventlog.clear'
+                    }
+                ],
+                label: 'eventlog'
+            },
+            {
+                enums: [
+                    { label: 'smu.ON' }
+                ],
+                label: 'smu'
+            }
+        ]
+        // Removes exclusive enumerations
+        const specD: ApiSpec = {
+            enums: [
+                { label: 'display.NFORMAT_DECIMAL' }
+            ],
+            label: 'display'
+        }
+
+        // it.skip('returns a CommandSet containing items which match the given ApiSpec')
+        // it.skip('returns a CommandSet whose signatures have been formatted according the given InstrumentSpec')
+        // it.skip('returns a CommandSet without extra items')
+
+        // it.skip('assignment completions')
+        // it.skip('populates same-namespace enumeration specs')
+        // it.skip('populates cross-namespace enumeration specs')
+
+        // it.skip('parameter completions')
+        // it.skip('populates the correct parameter')
+        // it.skip('populates the correct signature qualifier')
+        // it.skip('populates same-namespace enumeration specs')
+        // it.skip('populates cross-namespace enumeration specs')
     })
 })

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -59,7 +59,19 @@ interface TestCase {
     expected: Array<ExpectedCompletion>
     given: Given
     /**
-     * A **descriptive** test name.
+     * The test name.
+     */
+    name: string
+}
+
+interface ErrorCase {
+    /**
+     * The expected error message.
+     */
+    expected: string
+    given: Given
+    /**
+     * The test name.
      */
     name: string
 }
@@ -365,7 +377,7 @@ describe('Instrument Provider', () => {
                 })
             })
 
-            describe(`${test.name}`, () => {
+            describe(test.name, () => {
                 test.expected.forEach((apiEntry: ExpectedCompletion) => {
                     let matchingCompletion: CompletionItem
 
@@ -542,6 +554,62 @@ describe('Instrument Provider', () => {
 
                 it('Contains no additional #signatures', () => {
                     expect(commandSet.signatures.length).to.equal(signatureLength)
+                })
+            })
+        })
+
+        const errorCases: Array<ErrorCase> = [
+            {
+                expected: 'Unable to satisfy assignment exclusives for "smu.reset"',
+                given: {
+                    api: [
+                        {
+                            children: [
+                                {
+                                    assignmentExclusives: [
+                                        { label: 'foo' }
+                                    ],
+                                    label: 'smu.reset'
+                                }
+                            ],
+                            label: 'smu'
+                        },
+                    ],
+                    spec: emptySpec
+                },
+                name: 'Errors when no assignment exclusives can be satisfied'
+            },
+            {
+                expected: 'Unable to satisfy assignment exclusives for "smu.reset"',
+                given: {
+                    api: [
+                        {
+                            children: [
+                                {
+                                    assignmentExclusives: [
+                                        { label: 'smu.ON' },
+                                        { label: 'foo.BAR' }
+                                    ],
+                                    label: 'smu.reset'
+                                }
+                            ],
+                            label: 'smu'
+                        },
+                    ],
+                    spec: emptySpec
+                },
+                name: 'Errors when some assignment exclusives cannot be satisfied'
+            }
+        ]
+
+        describe('Error Tests', () => {
+            errorCases.forEach((errorTest: ErrorCase) => {
+                it(errorTest.name, () => {
+                    expect(
+                        () => {
+                            generateCommandSet(errorTest.given.api, errorTest.given.spec)
+                        }
+                    ).to.throw(errorTest.expected)
                 })
             })
         })

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -24,5 +24,19 @@ import { generateCommandSet } from '../../../instrument/provider'
 describe('Instrument Provider', () => {
     describe('generateCommandSet()', () => {
         it.skip('needs test coverage')
+
+        it.skip('returns a CommandSet containing items which match the given ApiSpec')
+        it.skip('returns a CommandSet whose signatures have been formatted according the given InstrumentSpec')
+        it.skip('returns a CommandSet without extra items')
+
+        it.skip('assignment completions')
+        it.skip('populates same-namespace enumeration specs')
+        it.skip('populates cross-namespace enumeration specs')
+
+        it.skip('parameter completions')
+        it.skip('populates the correct parameter')
+        it.skip('populates the correct signature qualifier')
+        it.skip('populates same-namespace enumeration specs')
+        it.skip('populates cross-namespace enumeration specs')
     })
 })

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -267,6 +267,23 @@ describe('Instrument Provider', () => {
                         label: 'buffer.write'
                     },
                     {
+                        label: 'buffer.write.format',
+                        signatures: [
+                            {
+                                exclusives: new Map([
+                                    [
+                                        0,
+                                        [
+                                            'buffer',
+                                            'buffer.OFF'
+                                        ]
+                                    ]
+                                ]),
+                                loaded: false
+                            }
+                        ]
+                    },
+                    {
                         exclusives: [
                             'buffer',
                             'buffer.FILL_CONTINUOUS',
@@ -307,6 +324,22 @@ describe('Instrument Provider', () => {
                     api: [
                         {
                             children: [
+                                {
+                                    // Creates SignatureInformation.data during parameter exclusive population.
+                                    label: 'buffer.write.format',
+                                    signatureExclusives: [
+                                        {
+                                            parameters: new Map([
+                                                [
+                                                    0,
+                                                    [
+                                                        { label: 'buffer.OFF' }
+                                                    ]
+                                                ]
+                                            ])
+                                        }
+                                    ]
+                                },
                                 {
                                     // Populates assignment exclusives
                                     assignmentExclusives: [
@@ -593,12 +626,74 @@ describe('Instrument Provider', () => {
                                     label: 'smu.reset'
                                 }
                             ],
+                            enums: [
+                                { label: 'smu.ON' }
+                            ],
                             label: 'smu'
                         },
                     ],
                     spec: emptySpec
                 },
                 name: 'Errors when some assignment exclusives cannot be satisfied'
+            },
+            {
+                expected: 'Unable to satisfy exclusives for parameter 0 of "buffer.make"',
+                given: {
+                    api: [
+                        {
+                            children: [
+                                {
+                                    label: 'buffer.make',
+                                    signatureExclusives: [
+                                        {
+                                            parameters: new Map([
+                                                [0, [{ label: 'foo' }]]
+                                            ])
+                                        }
+                                    ]
+                                }
+                            ],
+                            label: 'buffer'
+                        }
+                    ],
+                    spec: emptySpec
+                },
+                name: 'Errors when no parameter exclusives can be satisfied'
+            },
+            {
+                expected: 'Unable to satisfy exclusives for parameter 1 of "buffer.make"',
+                given: {
+                    api: [
+                        {
+                            children: [
+                                {
+                                    label: 'buffer.make',
+                                    signatureExclusives: [
+                                        {
+                                            parameters: new Map([
+                                                [0, [{ label: 'buffer.UNIT_X' }]],
+                                                [
+                                                    1,
+                                                    [
+                                                        { label: 'buffer.STAT_TERMINAL' },
+                                                        { label: 'foo.BAR' }
+                                                    ]
+                                                ]
+                                            ])
+                                        }
+                                    ]
+                                }
+                            ],
+                            enums: [
+                                { label: 'buffer.STAT_TERMINAL' },
+                                { label: 'buffer.UNIT_X' }
+                            ],
+                            label: 'buffer'
+                        }
+                    ],
+                    spec: emptySpec
+                },
+                name: 'Errors when some parameter exclusives cannot be satisfied'
             }
         ]
 

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -82,11 +82,23 @@ describe('Instrument Provider', () => {
                         ]
                     },
                     {
+                        label: 'reset',
+                        signatures: [
+                            {
+                                loaded: false
+                            }
+                        ]
+                    },
+                    {
                         label: 'smu.measure'
                     },
                     {
                         formattable: true,
                         label: 'smu.measure.range'
+                    },
+                    {
+                        formattable: true,
+                        label: 'test/root.completion.docs'
                     }
                 ],
                 given: {
@@ -100,16 +112,58 @@ describe('Instrument Provider', () => {
                             label: 'beeper'
                         },
                         {
+                            // Gets root namespace signatures.
+                            label: 'reset'
+                        },
+                        {
                             children: [
-                                // Gets completion documentation
+                                // Gets completion documentation.
                                 { label: 'smu.measure.range' }
                             ],
                             label: 'smu.measure'
+                        },
+                        {
+                            // Gets root namespace completion documentation.
+                            label: 'test/root.completion.docs'
+                        },
+                        // Get a provider file that doesn't export a completion with the same name.
+                        {
+                            label: 'keywords'
                         }
                     ],
                     spec: emptySpec
                 },
                 name: 'Basic Test'
+            },
+            {
+                expected: [
+                    {
+                        label: 'beeper'
+                    },
+                    {
+                        label: 'beeper.beep',
+                        signatures: [
+                            {
+                                formattable: true,
+                                loaded: true
+                            }
+                        ]
+                    }
+                ],
+                given: {
+                    api: [
+                        {
+                            children: [
+                                { label: 'beeper.beep' },
+                                // Try to get a completion that shouldn't exist here.
+                                { label: 'smu.measure.range' }
+                            ],
+                            label: 'beeper'
+                        }
+                    ],
+                    spec: emptySpec
+                },
+                name: 'Loaded Signature Test'
             },
             {
                 expected: [
@@ -121,7 +175,9 @@ describe('Instrument Provider', () => {
                     api: [
                         {
                             enums: [
-                                { label: 'display.NFORMAT_DECIMAL' }
+                                { label: 'display.NFORMAT_DECIMAL' },
+                                // Try to get an enumeration that shouldn't exist here
+                                { label: 'smu.ON' }
                             ],
                             label: 'display'
                         }
@@ -413,6 +469,12 @@ describe('Instrument Provider', () => {
                                     matchingSignature = matchingLabelSignatures.pop()
                                 }
                             })
+
+                            if (signatureEntry.loaded) {
+                                it(`${apiEntry.label}: has already been loaded`, () => {
+                                    expect(matchingSignature._loaded).to.be.true
+                                })
+                            }
 
                             if (signatureEntry.formattable === true) {
                                 it(`${apiEntry.label}: parameters are formatted correctly`, () => {

--- a/server/src/test/instrument/provider/index.test.ts
+++ b/server/src/test/instrument/provider/index.test.ts
@@ -19,7 +19,7 @@ import { expect } from 'chai'
 import 'mocha'
 // tslint:enable:no-implicit-dependencies
 
-import { generateCommandSet } from '../../instrument/provider'
+import { generateCommandSet } from '../../../instrument/provider'
 
 describe('Instrument Provider', () => {
     describe('generateCommandSet()', () => {

--- a/server/src/tspItem.ts
+++ b/server/src/tspItem.ts
@@ -27,27 +27,17 @@ export interface TspItem {
     shebang: Shebang
 }
 export namespace TspItem {
-    export async function create(
+    export function create(
         registrant: TextDocument,
         shebang: Shebang,
         settings: TsplangSettings,
         pool: TspPool
-    ): Promise<TspItem> {
-        return new Promise<TspItem>(async (
-            resolve: (value?: TspItem) => void,
-            reject: (reason?: Error) => void
-        ): Promise<void> => {
-            try {
-                const entry = await pool.register(shebang.master)
+    ): TspItem {
+        const entry = pool.register(shebang.master)
 
-                resolve({
-                    shebang,
-                    context: new DocumentContext(entry.commandSet, registrant, settings)
-                })
-            }
-            catch (e) {
-                reject(e)
-            }
-        })
+        return {
+            shebang,
+            context: new DocumentContext(entry.commandSet, registrant, settings)
+        }
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
Please review the [Contribution Guidelines](../CONTRIBUTING.md) before submitting.

- [x] Pulling from a topic/feature/bugfix branch (right side).
- [x] Pulling against the `dev` branch (left side).
- [x] Code passes linting.
- [x] Code passes unit tests.
- [x] Code coverage is the same or better.
- [x] You have previously submitted a Contributor License Agreement or have contacted a maintainer to request one.

### Description
#### Additions
* Unit tests for the `generateCommandSet` function exported by the Instrument Provider.

#### Changes
* Removed async from all functions.
* 2450, 2460, & Lua tests now have a test case for all expected namespaces.

#### Fixes
* `generateCommandSet` didn't respect the enumeration list provided in the API specification and, instead, always provided all enumerations. Added the missing `filterEnums` call.


<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
